### PR TITLE
AnimatedPullToRefresh.js small update >> make values after PropTypes optional

### DIFF
--- a/src/AnimatedPullToRefresh.js
+++ b/src/AnimatedPullToRefresh.js
@@ -39,27 +39,27 @@ class AnimatedPullToRefresh extends React.Component {
      * Refresh state set by parent to trigger refresh
      * @type {Boolean}
      */
-    isRefreshing: PropTypes.bool.isRequired,
+    isRefreshing: PropTypes?.bool.isRequired,
     /**
      * Pull Distance
      * @type {Integer}
      */
-    pullHeight: PropTypes.number,
+    pullHeight: PropTypes?.number,
     /**
      * Callback after refresh event
      * @type {Function}
      */
-    onRefresh: PropTypes.func.isRequired,
+    onRefresh: PropTypes?.func.isRequired,
     /**
      * The content: ScrollView or ListView
      * @type {Object}
      */
-    contentView: PropTypes.object.isRequired,
+    contentView: PropTypes?.object.isRequired,
     /**
      * Background color
      * @type {string}
      */
-    animationBackgroundColor: PropTypes.string,
+    animationBackgroundColor: PropTypes?.string,
     /**
      * Custom onScroll event
      * @type {Function}


### PR DESCRIPTION
The library crashed due to not finding the properties after PropTypes in AnimatedPullToRefresh.js, so I decided to make them optional using `?.`.
Now the library works very nicely on IOS (the description says that it's only for Android).
Thank you